### PR TITLE
Add configurable creeper and vindicator speed bonuses

### DIFF
--- a/src/main/java/net/scirave/nox/config/NoxConfig.java
+++ b/src/main/java/net/scirave/nox/config/NoxConfig.java
@@ -109,6 +109,8 @@ public class NoxConfig extends MidnightConfig {
     public static boolean creepersRunFromShields = true;
     @Entry
     public static boolean creepersAttackShields = false;
+    @Entry
+    public static double creeperSpeedMultiplier = 1.5;
 
     // Effects
     @Comment(centered = true)
@@ -245,6 +247,8 @@ public class NoxConfig extends MidnightConfig {
     public static boolean evokersImmuneToMagic = true;
     @Entry
     public static double vindicatorKnockbackResistanceBonus = 0.3;
+    @Entry
+    public static double vindicatorSpeedBonus = 1.25;
 
     // Phantoms
     @Comment(centered = true)

--- a/src/main/java/net/scirave/nox/mixin/CreeperEntityMixin.java
+++ b/src/main/java/net/scirave/nox/mixin/CreeperEntityMixin.java
@@ -12,10 +12,15 @@
 package net.scirave.nox.mixin;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.ai.goal.FleeEntityGoal;
 import net.minecraft.entity.ai.goal.PounceAtTargetGoal;
+import net.minecraft.entity.attribute.EntityAttributeModifier;
+import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.mob.CreeperEntity;
+import net.minecraft.entity.mob.ZombieEntity;
+import net.minecraft.world.World;
 import net.scirave.nox.config.NoxConfig;
 import net.scirave.nox.goals.Nox$CreeperBreachGoal;
 import net.scirave.nox.util.Nox$CreeperBreachInterface;
@@ -47,6 +52,13 @@ public abstract class CreeperEntityMixin extends HostileEntityMixin implements N
         }));
         if (NoxConfig.creeperBreachDistance > 0) {
             this.goalSelector.add(3, new Nox$CreeperBreachGoal((CreeperEntity) (Object) this));
+        }
+    }
+
+    @Override
+    public void nox$modifyAttributes(EntityType<?> entityType, World world, CallbackInfo ci) {
+        if (NoxConfig.creeperSpeedMultiplier > 1) {
+            this.getAttributeInstance(EntityAttributes.GENERIC_MOVEMENT_SPEED).addTemporaryModifier(new EntityAttributeModifier("Nox: Creeper speed bonus", NoxConfig.creeperSpeedMultiplier - 1, EntityAttributeModifier.Operation.MULTIPLY_BASE));
         }
     }
 

--- a/src/main/java/net/scirave/nox/mixin/VindicatorEntityMixin.java
+++ b/src/main/java/net/scirave/nox/mixin/VindicatorEntityMixin.java
@@ -37,8 +37,10 @@ public abstract class VindicatorEntityMixin extends HostileEntityMixin {
             if (attr != null)
                 attr.addTemporaryModifier(new EntityAttributeModifier("Nox: Vindicator bonus", NoxConfig.vindicatorKnockbackResistanceBonus, EntityAttributeModifier.Operation.ADDITION));
         }
+        if (NoxConfig.vindicatorSpeedBonus > 1) {
+                this.getAttributeInstance(EntityAttributes.GENERIC_MOVEMENT_SPEED).addTemporaryModifier(new EntityAttributeModifier("Nox: Vindicator speed bonus", NoxConfig.vindicatorSpeedBonus - 1, EntityAttributeModifier.Operation.MULTIPLY_BASE));
+        }
     }
-
     @Override
     public boolean nox$isAllowedToMine() {
         return NoxConfig.vindicatorsBreakBlocks;

--- a/src/main/resources/assets/nox/lang/en_us.json
+++ b/src/main/resources/assets/nox/lang/en_us.json
@@ -80,6 +80,8 @@
   "nox.midnightconfig.creepersRunFromShields.tooltip": "Creepers will run from shielding Players",
   "nox.midnightconfig.creepersAttackShields": "Creepers Attack Shields",
   "nox.midnightconfig.creepersAttackShields.tooltip": "Creepers attack shielding players",
+  "nox.midnightconfig.creeperSpeedBonus": "Creeper Speed Multiplier",
+  "nox.midnightconfig.creeperSpeedBonus.tooltip": "Creeper movement speed multiplier",
 
   "nox.midnightconfig.comment_effects": "Effects",
   "nox.midnightconfig.caveSpiderSlownessBiteDuration": "Cave Spider Slowness Bite Duration",
@@ -202,6 +204,8 @@
   "nox.midnightconfig.evokersResistProjectiles.tooltip": "Evokers are immune to non-armor-piercing projectiles",
   "nox.midnightconfig.vindicatorKnockbackResistanceBonus": "Vindicator Knockback Resistance Bonus",
   "nox.midnightconfig.vindicatorKnockbackResistanceBonus.tooltip": "Vindicator knockback resistance bonus",
+  "nox.midnightconfig.vindicatorSpeedBonus":  "Vindicator speed multiplier",
+  "nox.midnightconfig.vindicatorSpeedBonus.tooltip":  "Vindicator movement speed multiplier",
 
   "nox.midnightconfig.comment_phantoms": "Phantoms",
   "nox.midnightconfig.phantomsPhaseThroughBlocks": "Phantoms Phase Through Blocks",


### PR DESCRIPTION
I've playtested a little bit and they seem balanced. You can still run away from both, it just makes walking backwards and hitting a little harder. If you want me to change the default values let me know.