### PR TITLE
Update nox_cant_mine.json

### DIFF
--- a/src/main/resources/data/c/tags/blocks/nox_cant_mine.json
+++ b/src/main/resources/data/c/tags/blocks/nox_cant_mine.json
@@ -1,12 +1,17 @@
 {
   "replace": false,
   "values": [
-    "#climbable",
     "minecraft:tinted_glass",
+    "#banners",
+    "#buttons",
+    "#candles",
+    "#climbable",
+    "#crops",
     "#pressure_plates",
     "#rails",
-    "#replaceable_plants",
+    "#replaceable",
     "#saplings",
-    "#signs"
+    "#flowers",
+    "#all_signs"
   ]
 }


### PR DESCRIPTION
I noticed an error in the console; turns out 1.20 removed the `#replaceable_plants` tag. I swapped it for the [`#replaceable`](https://minecraft.wiki/w/Tag#blocks_replaceable) tag. I also added `#banners`, `#buttons`, `#candles`, `#crops`, `#flowers`, and `#all_signs` tags as mobs can walk through these anyway.